### PR TITLE
ci: Remove support for go 1.18.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.18', '1.19.x', '1.20.x' ]
+        go-version: [ '1.19.x', '1.20.x' ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Newer versions of modules, such as Viper won't support 1.18 anyway. Time to let it go.